### PR TITLE
Added DEBUG and ALLOWED_HOSTS environment variables to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ To deploy the container:
 Example `.env` file structure:
 
 ```ini
+ALLOWED_HOSTS="renaldata1.exampledomain.com,renaldata2.exampledomain.com"
+DEBUG=0
+
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/src/mauritiusrenalregistry/settings.py
+++ b/src/mauritiusrenalregistry/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 import os
 import secrets
+from typing import List
 
 from django.contrib.messages import constants as messages
 
@@ -23,14 +24,14 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(int(os.environ.get('DEBUG', 0)))
+DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 
 # Array of hosts that are allowed to access the site when debug mode is off
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: List[str] = []
 ALLOWED_HOSTS.extend(
     filter(  # Remove empty strings
         None,
-        os.environ.get('ALLOWED_HOSTS', '').split(','),
+        os.environ.get("ALLOWED_HOSTS", "").split(","),
     )
 )
 

--- a/src/mauritiusrenalregistry/settings.py
+++ b/src/mauritiusrenalregistry/settings.py
@@ -23,7 +23,16 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = bool(int(os.environ.get('DEBUG', 0)))
+
+# Array of hosts that are allowed to access the site when debug mode is off
+ALLOWED_HOSTS = []
+ALLOWED_HOSTS.extend(
+    filter(  # Remove empty strings
+        None,
+        os.environ.get('ALLOWED_HOSTS', '').split(','),
+    )
+)
 
 # Look for a secret key environment variable, otherwise generate a random key
 # Random key will not persist across sessions, so avoid in production environments!
@@ -120,15 +129,10 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
-
 TIME_ZONE = "UTC"
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/


### PR DESCRIPTION
Adds environment variables for DEBUG and ALLOWED_HOSTS.

Note: Minor "breaking" change this disables debug mode by default, meaning that ALLOWED_HOSTS must be set (or DEBUG enabled) for the application to work from any non-loopback (127.0.0.1) host.