### PR TITLE
Serve static files from docker-compose stack

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,4 +1,4 @@
-name: Test and Publish Docker image
+name: Test
 
 on:
   push:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -2,13 +2,6 @@ name: Test and Publish Docker image
 
 on:
   push:
-    branches:
-      - "**"
-    tags:
-      - "v*.*.*"
-  pull_request:
-    branches:
-      - "master"
 
 jobs:
   test:
@@ -29,39 +22,3 @@ jobs:
 
       - name: Test with tox
         run: tox
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: test
-
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ghcr.io/renalreg/mauritius-renaldataregistry
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .vscode/
+
+# Collected static files
+src/static

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ You can reference images by various tags:
 
 To deploy the container:
 
-1. Copy `docker-compose.yml` to the host machine
-2. Create a `.env` file populated as shown below
-3. Run `docker-compose up`
+1. Clone this repository to your server
+2. Create a populated `.env` file in the root of the repository
+3. Run `docker-compose up` (or `docker-compose up -d` to run in the background)
+
+The application will be running on port 8000, so set up your reverse proxy to redirect requests to that port.
+
+The docker-compose file is set up to also serve collected static files, so no downstream configuration is required for static files.
 
 #### Environment variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     env_file:
       - .env
     volumes:
+      # We need to serve collected static files from our nginx container (below)
+      # so we mount the nginx container's static files volume here.
       - static_files:/src/static
     depends_on:
       db:
@@ -29,6 +31,8 @@ services:
     image: nginx:1.19.6
     volumes:
       - ./nginx:/etc/nginx/templates
+      # Use the collected static files from our 'web' container (above) as the
+      # source of static files for our nginx container.
       - static_files:/var/www/static
     ports:
       - 8000:9999

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.1"
 
 services:
   db:
@@ -8,19 +8,37 @@ services:
     env_file:
       - .env
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
       timeout: 5s
       retries: 5
 
   web:
-    image: ghcr.io/renalreg/mauritius-renaldataregistry:main
+    build: .
     environment:
       - POSTGRES_HOST=db
     env_file:
       - .env
-    ports:
-      - "8000:8000"
+    volumes:
+      - static_files:/src/static
     depends_on:
       db:
         condition: service_healthy
+
+  nginx:
+    image: nginx:1.19.6
+    volumes:
+      - ./nginx:/etc/nginx/templates
+      - static_files:/var/www/static
+    ports:
+      - 8000:9999
+    environment:
+      - APP_HOST=web
+      - APP_PORT=8000
+      - PORT=9999
+    depends_on:
+      - web
+    restart: always
+
+volumes:
+  static_files:

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,15 @@
+server {
+    listen ${PORT};
+    listen [::]:${PORT};
+
+    location /static {
+        autoindex on;
+        alias /var/www/static;
+    }
+
+    location / {
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://${APP_HOST}:${APP_PORT};
+  }
+}

--- a/src/users/admin.py
+++ b/src/users/admin.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth import get_user_model
@@ -65,7 +67,7 @@ class CustomUserAdmin(UserAdmin):
 class GroupAdminForm(forms.ModelForm):
     class Meta:
         model = Group
-        exclude: list[str] = []
+        exclude: List[str] = []
 
     User = get_user_model()
     users = forms.ModelMultipleChoiceField(

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -15,7 +17,7 @@ class CustomUser(AbstractUser):
     email = models.EmailField(_("email address"), unique=True)
 
     USERNAME_FIELD = "email"
-    REQUIRED_FIELDS: list[str] = []
+    REQUIRED_FIELDS: List[str] = []
 
     objects = CustomUserManager()  # type: ignore
 


### PR DESCRIPTION
This changes our deployment strategy from pulling a pre-built image to instead building the image on the deployment server.

This allows us to include static files serving within the stack, meaning the entire application (including static files) are served from a single port on the host (default 8000).

This will massively simplify downstream reverse proxy configuration.